### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Model Context Protocol (MCP) server implementation for the Deepseek R1 languag
 Why Node.js?
 This implementation uses Node.js/TypeScript as it provides the most stable integration with MCP servers. The Node.js SDK offers better type safety, error handling, and compatibility with Claude Desktop.
 
+<a href="https://glama.ai/mcp/servers/qui5thpyvu"><img width="380" height="200" src="https://glama.ai/mcp/servers/qui5thpyvu/badge" alt="Deepseek R1 Server MCP server" /></a>
+
 ## Quick Start
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [Deepseek R1 MCP Server](https://glama.ai/mcp/servers/qui5thpyvu) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qui5thpyvu"><img width="380" height="200" src="https://glama.ai/mcp/servers/qui5thpyvu/badge" alt="Deepseek R1 Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.